### PR TITLE
Fix invalid icon on agent prompt controls

### DIFF
--- a/src/app/clientside/A2AAgentClient.jsx
+++ b/src/app/clientside/A2AAgentClient.jsx
@@ -22,7 +22,7 @@ import {
   Tag,
   Tooltip,
 } from '@chakra-ui/react'
-import { FiCopy, FiEyeOff, FiSparkles, FiRotateCcw } from 'react-icons/fi'
+import { FiCopy, FiEyeOff, FiRotateCcw, FiZap } from 'react-icons/fi'
 import { useAuth } from '../context/AuthContext'
 import ContentWrapper from '../_components/layout/ContentWrapper'
 import AgentSidebar from './agents/AgentSidebar'
@@ -356,7 +356,7 @@ export default function A2AAgentClient() {
                     {hasPrompts && !showPromptPanel && (
                       <Button
                         size="sm"
-                        leftIcon={<FiSparkles />}
+                        leftIcon={<FiZap />}
                         borderRadius="12px"
                         onClick={() => setShowPromptPanel(true)}
                       >
@@ -471,7 +471,7 @@ export default function A2AAgentClient() {
                                   </Stack>
                                   <Button
                                     size="sm"
-                                    leftIcon={<FiSparkles />}
+                                    leftIcon={<FiZap />}
                                     borderRadius="12px"
                                     onClick={() => {
                                       setPrompt(text)


### PR DESCRIPTION
## Summary
- replace the nonexistent FiSparkles icon with the available FiZap icon in the agent client
- ensure prompt suggestion actions render with a valid icon to prevent runtime crashes when selecting Supabase agents

## Testing
- npm run lint *(fails: Failed to load config "next/babel" to extend from)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106c7f633c832995a20513839301f8)