### PR TITLE
Update Brand Agent configuration and prompts

### DIFF
--- a/src/app/api/a2a/[agent]/route.js
+++ b/src/app/api/a2a/[agent]/route.js
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic';
 
 // Map agent slug => upstream URL (from Postman collections - verified working)
 const AGENT_URLS = {
-  brand: 'https://a2a-crm-agent-app-bt5gn1.7y6hwo.usa-e2.cloudhub.io/crm-agent',
+  brand: 'https://hushh-brand-agent-app-bubqpu.5sc6y6-4.usa-e2.cloudhub.io/crm-agent',
   // Legacy headless endpoint now returns 500s because its upstream Supabase call fails
   // with a 400 that lacks a Content-Type header. Switch to the new Query Agent host.
   hushh: 'https://hushh-supabase-query-agent-app-bubqpu.5sc6y6-2.usa-e2.cloudhub.io/supabase-query-agent',

--- a/src/app/clientside/A2AAgentClient.jsx
+++ b/src/app/clientside/A2AAgentClient.jsx
@@ -33,6 +33,24 @@ import WhatsappComposer from './agents/WhatsappComposer'
 import { AGENT_OPTIONS, CHAT_ENABLED_AGENT_IDS, getAgentOptionById } from './agents/agentOptions'
 
 const PROMPT_TEMPLATES = {
+  brand: [
+    {
+      label: 'Lookup user state by phone',
+      text: 'Can you get the state of the user having phone: +919346661428?'
+    },
+    {
+      label: 'Fetch full brand profile',
+      text: 'Can you fetch all the details of the user with phone number (637) 940-5403?'
+    },
+    {
+      label: 'Retrieve user wants and desires',
+      text: 'Can you fetch all the wants and desires of the user with phone number (637) 940-5403?'
+    },
+    {
+      label: 'Check lifestyle preference',
+      text: 'Does the user with phone number (637) 940-5403 like tea or coffee?'
+    },
+  ],
   'hushh-profile': [
     {
       label: 'Create a profile with full details',

--- a/src/app/clientside/agents/agentOptions.js
+++ b/src/app/clientside/agents/agentOptions.js
@@ -4,8 +4,8 @@ export const AGENT_OPTIONS = [
   {
     id: 'brand',
     name: 'Brand Agent',
-    description: 'CRM user intelligence',
-    tagline: 'Understand CRM profiles and surface conversational insights instantly.',
+    description: 'Salesforce CRM bridge for brand preferences',
+    tagline: 'Query user affinity data with natural language and sync it back securely.',
     accent: {
       gradient: 'linear(135deg, #6366F1 0%, #8B5CF6 100%)',
       softBg: 'rgba(99, 102, 241, 0.12)',

--- a/src/lib/config/agentConfig.js
+++ b/src/lib/config/agentConfig.js
@@ -2,7 +2,7 @@
 // These URLs match the working Postman collection endpoints
 
 export const AGENT_API_URLS = {
-  brand: 'https://a2a-crm-agent-app-bt5gn1.7y6hwo.usa-e2.cloudhub.io/crm-agent',
+  brand: 'https://hushh-brand-agent-app-bubqpu.5sc6y6-4.usa-e2.cloudhub.io/crm-agent',
   hushh: 'https://hushh-supabase-query-agent-app-bubqpu.5sc6y6-2.usa-e2.cloudhub.io/supabase-query-agent',
   'hushh-profile': 'https://hushh-supabase-agent-app-bubqpu.5sc6y6-2.usa-e2.cloudhub.io/supabase-agent',
   'hushh-profile-update': 'https://hushh-supabase-agent-app-bubqpu.5sc6y6-2.usa-e2.cloudhub.io/supabase-agent',


### PR DESCRIPTION
## Summary
- point the Brand Agent proxy to the new CloudHub host to restore API calls
- refresh the Brand Agent sidebar copy to reflect its Salesforce data role
- add ready-to-use Brand Agent prompt templates that match the latest documentation

## Testing
- npm run lint *(fails: Failed to load config "next/babel" to extend from.)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691071e954148329989632ef499a51f7)