### PR TITLE
Add quick start prompts for public data agent

### DIFF
--- a/src/app/clientside/A2AAgentClient.jsx
+++ b/src/app/clientside/A2AAgentClient.jsx
@@ -75,6 +75,38 @@ const PROMPT_TEMPLATES = {
         'Please update Sundhar Pichai’s city to Mountain View and email to sundar.pichai@google.com in the database having their +52 334i33 and user id d72882hgdt7889.',
     },
   ],
+  gemini: [
+    {
+      label: 'Enrich via Gemini Public Data Agent',
+      text:
+        "Using the Gemini Public Data Agent, provide a detailed JSON profile for Sundhar Pichai with phone +1-555-0123 and email sundhar.pichai@example.com. Include every possible field such as full name, phone, email, address, age, gender, marital status, household size, children count, education level, occupation, income bracket, home ownership, city tier, transport, diet preference, favorite cuisine, coffee or tea choice, fitness routine, gym membership, shopping preference, grocery store type, fashion style, tech affinity, primary device, favorite social platform, social media usage time, content preference, sports interest, gaming preference, travel frequency, eco-friendliness, sleep chronotype, needs, wants, desires, and intents for 24h, 48h, and 72h with category, budget, time window, and confidence.",
+    },
+    {
+      label: 'Compose Gemini JSON-RPC request',
+      text: `{
+  "jsonrpc": "2.0",
+  "id": "task124",
+  "method": "tasks/send",
+  "params": {
+    "sessionId": "session456",
+    "message": {
+      "role": "user",
+      "parts": [
+        {
+          "type": "text",
+          "text": "Can you enrich this lead with a comprehensive userProfile JSON using their name, email, and phone number via the Gemini Public Data Agent?"
+        }
+      ]
+    }
+  }
+}`,
+    },
+    {
+      label: 'Summarize Gemini integration steps',
+      text:
+        'Summarize the workflow for the GeminiAI Public Data Agent from the user entering basic identifiers in Hushh through MuleSoft orchestration, enrichment, storage, and dashboard visualization.',
+    },
+  ],
   public: [
     {
       label: 'Enrich Sundhar Pichai\'s public profile',


### PR DESCRIPTION
## Summary
- add curated quick start prompts for the OpenAI Public Data Agent
- include templates for enrichment requests, JSON-RPC payloads, and integration workflow reviews

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691094b4ac408329bbb63070897c38bc)