### PR TITLE
fix: add next-mdx-remote@6.0.0 as direct dependency (CVE-2026-0969)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "next-cloudinary": "^6.6.2",
         "next-contentlayer": "^0.3.4",
         "next-images": "^1.8.5",
+        "next-mdx-remote": "6.0.0",
         "next-sitemap": "^4.2.3",
         "next-themes": "^0.3.0",
         "nextjs-toploader": "^1.6.11",
@@ -3190,8 +3191,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8283,6 +8282,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz",
+      "integrity": "sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
@@ -22865,8 +22873,6 @@
     },
     "node_modules/next-mdx-remote/node_modules/remark-mdx": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
-      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
       "license": "MIT",
       "dependencies": {
         "mdast-util-mdx": "^3.0.0",
@@ -22931,8 +22937,6 @@
     },
     "node_modules/next-mdx-remote/node_modules/unist-util-is": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "next-cloudinary": "^6.6.2",
     "next-contentlayer": "^0.3.4",
     "next-images": "^1.8.5",
+    "next-mdx-remote": "6.0.0",
     "next-sitemap": "^4.2.3",
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^1.6.11",


### PR DESCRIPTION
## Summary
Follow-up fix for the Vercel build error (CVE-2026-0969). The previous override-only approach wasn't sufficient for Vercel's vulnerability detection.

## Changes
- Added `next-mdx-remote@6.0.0` as a **direct dependency** (ensures Vercel detects v6.0.0)
- Created `.npmrc` with `legacy-peer-deps=true` (ensures `npm install` works on Vercel with peer dep conflicts)
- Regenerated `package-lock.json`

## Verification
```
npm ls next-mdx-remote
├── next-mdx-remote@6.0.0 overridden
└─┬ nextra@2.13.4
  └── next-mdx-remote@6.0.0 deduped
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize dependency installation
  * Added framework enhancement to support additional content rendering capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->