### PR TITLE
fix: professional gray SVG icons + hide funding banner

### DIFF
--- a/src/app/plaid-balance/_components/styles.js
+++ b/src/app/plaid-balance/_components/styles.js
@@ -23,13 +23,16 @@ export const colors = {
   white: "#FFFFFF",
 };
 
+// Professional SVG icons (gray, 16px)
+const icon = (path) => `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%238E8E93" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${path}</svg>`)}`;
+
 export const TABS = [
-  { id: "overview", label: "Overview", icon: "📊" },
-  { id: "live-test", label: "Live Test", icon: "🧪" },
-  { id: "api-docs", label: "API Docs", icon: "📖" },
-  { id: "api-tester", label: "API Tester", icon: "⚡" },
-  { id: "architecture", label: "Architecture", icon: "🏗️" },
-  { id: "use-cases", label: "Use Cases", icon: "💡" },
+  { id: "overview", label: "Overview", icon: icon('<rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>') },
+  { id: "live-test", label: "Live Test", icon: icon('<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>') },
+  { id: "api-docs", label: "API Docs", icon: icon('<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>') },
+  { id: "api-tester", label: "API Tester", icon: icon('<polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>') },
+  { id: "architecture", label: "Architecture", icon: icon('<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>') },
+  { id: "use-cases", label: "Use Cases", icon: icon('<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>') },
 ];
 
 export const s = {

--- a/src/app/plaid-balance/page.js
+++ b/src/app/plaid-balance/page.js
@@ -48,9 +48,13 @@ export default function PlaidBalancePage() {
       "[class*='Header']", "[class*='header']",
       "[class*='Footer']", "[class*='footer']",
       "[class*='Banner']", "[class*='banner']",
+      "[class*='Funding']", "[class*='funding']",
       "[class*='FundingBanner']",
       "[class*='HushhBot']", "[class*='hushhBot']",
       "[class*='TopLoader']", "[class*='toploader']",
+      "[class*='announcement']", "[class*='Announcement']",
+      "[style*='position: fixed']",
+      "[style*='position: sticky']",
     ];
     const hidden = [];
     hideSelectors.forEach((sel) => {
@@ -259,7 +263,7 @@ export default function PlaidBalancePage() {
               </div>
               {TABS.map((tab) => (
                 <button key={tab.id} style={s.navItem(activeTab === tab.id)} onClick={() => { setActiveTab(tab.id); if (isMobile) setSidebarOpen(false); }}>
-                  <span>{tab.icon}</span>
+                  <img src={tab.icon} alt="" width={16} height={16} style={{ opacity: activeTab === tab.id ? 1 : 0.6 }} />
                   <span>{tab.label}</span>
                 </button>
               ))}


### PR DESCRIPTION
- Replace emoji icons with professional Feather-style SVG icons in gray (#8E8E93)
- Hide the funding news banner from Plaid Balance portal
- Better selector coverage for hiding main site elements