### PR TITLE
fix: remove emoji icons, fix responsive overflow in hushh-v02

### DIFF
--- a/src/features/hushh-v02/HushhV02Page.jsx
+++ b/src/features/hushh-v02/HushhV02Page.jsx
@@ -177,7 +177,7 @@ export default function HushhV02Page() {
           threadCount={activeThread.length}
         />
 
-        <section className="mx-auto mt-8 w-full max-w-5xl md:mt-10">
+        <section className="mx-auto mt-8 w-full max-w-5xl overflow-x-hidden md:mt-10">
           {activeLane === "me" && !isReady && session ? (
             <ResearchCanvas
               phase={phase}

--- a/src/features/hushh-v02/components/ResultPanel.jsx
+++ b/src/features/hushh-v02/components/ResultPanel.jsx
@@ -1,10 +1,10 @@
 function Card({ title, children, className = "" }) {
   return (
     <section
-      className={`rounded-[1.5rem] border border-slate-200 bg-white/90 p-5 shadow-[0_18px_40px_-28px_rgba(15,23,42,0.35)] sm:rounded-[2rem] sm:p-6 ${className}`}
+      className={`overflow-hidden rounded-[1.5rem] border border-slate-200 bg-white/90 p-5 shadow-[0_18px_40px_-28px_rgba(15,23,42,0.35)] sm:rounded-[2rem] sm:p-6 ${className}`}
     >
       <h3 className="text-base font-semibold tracking-tight text-slate-900 sm:text-lg">{title}</h3>
-      <div className="mt-4">{children}</div>
+      <div className="mt-4 min-w-0">{children}</div>
     </section>
   );
 }
@@ -72,7 +72,7 @@ function SectionBlock({ label, section }) {
 function AnswerCockpit({ title, summary, confidence, warnings, impactSnapshot }) {
   return (
     <div className="space-y-5">
-      <p className="text-base leading-7 text-slate-900 sm:text-lg sm:leading-8">{title}</p>
+      <p className="break-words text-base leading-7 text-slate-900 sm:text-lg sm:leading-8">{title}</p>
       {summary ? <p className="text-sm leading-7 text-slate-600">{summary}</p> : null}
       <div className="flex flex-wrap items-center gap-3">
         {typeof confidence === "number" ? <Pill tone="blue">Confidence {confidence}</Pill> : null}
@@ -324,7 +324,7 @@ function MeContextRail({ session, dossier }) {
 
 function MeReadyState({ session, dossier, thread, onSuggestionSelect }) {
   return (
-    <div className="grid gap-4 sm:gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+    <div className="grid min-w-0 gap-4 sm:gap-6 lg:grid-cols-[1.15fr_0.85fr]">
       <Card title="Me Workspace" className="lg:col-span-2">
         <div className="space-y-5">
           <div className="flex flex-wrap items-center gap-3">

--- a/src/features/hushh-v02/components/SearchLaneTabs.jsx
+++ b/src/features/hushh-v02/components/SearchLaneTabs.jsx
@@ -1,26 +1,22 @@
 import { HUSHH_V02_LANES } from "../content/intents";
 
-const LANE_ICONS = { me: "🤫", web: "🌐", kai: "✦" };
-
 export default function SearchLaneTabs({ value, onChange }) {
   return (
     <div className="-mx-1 overflow-x-auto px-1 pb-1">
       <div className="inline-flex min-w-full items-center gap-1 rounded-2xl border border-slate-200 bg-slate-100/85 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] sm:min-w-0 sm:rounded-full">
         {HUSHH_V02_LANES.map((lane) => {
           const active = lane.value === value;
-          const icon = LANE_ICONS[lane.value] || "";
           return (
             <button
               key={lane.value}
               type="button"
               onClick={() => onChange(lane.value)}
-              className={`flex min-w-[5.75rem] flex-1 items-center justify-center gap-1.5 rounded-xl px-4 py-3 text-center text-sm font-semibold transition-all sm:min-w-[7rem] sm:rounded-full ${
+              className={`flex min-w-[5.75rem] flex-1 items-center justify-center rounded-xl px-4 py-3 text-center text-sm font-semibold transition-all sm:min-w-[7rem] sm:rounded-full ${
                 active
                   ? "bg-slate-950 text-white shadow-[0_12px_24px_-18px_rgba(15,23,42,0.72)]"
                   : "text-slate-600 hover:bg-white hover:text-slate-950"
               }`}
             >
-              <span className="text-xs leading-none">{icon}</span>
               {lane.label}
             </button>
           );

--- a/src/features/hushh-v02/sections/HushhV02Hero.jsx
+++ b/src/features/hushh-v02/sections/HushhV02Hero.jsx
@@ -1,7 +1,6 @@
 export default function HushhV02Hero() {
   return (
     <section className="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
-      <div className="mb-5 text-5xl leading-none sm:mb-6 sm:text-7xl md:text-8xl">🤫</div>
       <h1 className="max-w-3xl text-3xl font-extrabold tracking-[-0.04em] text-slate-950 sm:text-4xl sm:leading-[1.08] md:text-[4.25rem] md:leading-[1.02]">
         your personal intelligence agent
       </h1>

--- a/src/features/hushh-v02/sections/HushhV02SearchConsole.jsx
+++ b/src/features/hushh-v02/sections/HushhV02SearchConsole.jsx
@@ -177,7 +177,7 @@ export default function HushhV02SearchConsole({
         <form onSubmit={onSubmit} className="space-y-4 sm:space-y-5">
           <div className="relative">
             <span className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-slate-400">
-              {isMe ? "🤫" : "⌕"}
+              ⌕
             </span>
             <input
               value={query}


### PR DESCRIPTION
## Changes
- Remove all emoji icons (🤫, 🌐, ✦) from toggle tabs — plain text Me/Web/Kai
- Remove emoji from search input icon and hero section  
- Fix responsive overflow: overflow-hidden on Card, min-w-0 on grids, break-words on answers
- Add overflow-x-hidden to results section wrapper

Fixes content going off-screen on smaller viewports.