### PR TITLE
Update Hushh AI GA4 measurement ID

### DIFF
--- a/src/app/sitemetadata.jsx
+++ b/src/app/sitemetadata.jsx
@@ -19,7 +19,7 @@ export const siteMetadata = {
   keywords: 'data privacy, data monetization, user-controlled data, digital identity, personalized experiences, luxury consumers, AI-powered personalization, privacy-preserving technology, decentralized data, ethical advertising, data marketplace, human-AI interaction',
   phoneNumber: '(888) 462-1726',
   analytics: {
-    googleAnalyticsId: 'G-1PDGMHH7CL',
+    googleAnalyticsId: 'G-PPEF1CSJ5H',
   },
   organization: {
     name: 'Hushh',


### PR DESCRIPTION
## Summary\n- Update the Hushh AI website GA4 measurement ID to the active stream G-PPEF1CSJ5H.\n\n## Notes\n- This commit only changes src/app/sitemetadata.jsx.\n- Existing unrelated local worktree changes were not staged or committed.