### PR TITLE
chore: add Hushh AI bug intake form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,126 @@
+name: Hushh AI bug report
+description: Raise a reproducible bug for the Hushh cross-team bug tracker.
+title: "[bug] "
+labels:
+  - type:bug
+  - status:needs-triage
+  - sector:hushh-ai
+projects:
+  - hushh-labs/79
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for reproducible Hushh AI bugs only. Do not include secrets, tokens, private user data, or public security vulnerability details.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This is a bug, not a feature request or general task.
+          required: true
+        - label: This is not a security vulnerability, secret leak, privacy issue, or exploit report.
+          required: true
+  - type: dropdown
+    id: sector
+    attributes:
+      label: Sector
+      options:
+        - Hushh AI
+        - Hushh Research
+        - HushhTech
+    validations:
+      required: true
+  - type: dropdown
+    id: lead
+    attributes:
+      label: Lead
+      options:
+        - Ankit
+        - Kushal
+    validations:
+      required: true
+  - type: dropdown
+    id: owner
+    attributes:
+      label: Owner
+      options:
+        - Jhumma
+        - Kushal
+        - Ankit
+        - Akshat
+        - Unassigned
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - P0 Critical
+        - P1 High
+        - P2 Medium
+        - P3 Low
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Production
+        - UAT
+        - Local
+        - GitHub/CI
+    validations:
+      required: true
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected route, page, feature, or command
+      placeholder: "/developers, /api/example, npm run build, AI search flow"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken? Keep this concise and specific.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: User or team impact
+      description: Who is affected, how often it happens, and why fixing it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence link, screenshot, log, or recording
+      description: Add relevant proof. Do not paste secrets, tokens, or private user data.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/hushh-labs/hushh.ai-website/security/advisories/new
+    about: Report security issues privately. Do not open a public issue.


### PR DESCRIPTION
## Summary
- add a GitHub issue form for Hushh AI bug intake
- capture sector, lead, owner, severity, environment, impact, and evidence
- disable blank issues and route security reports to private advisories

## Verification
- parsed the issue form YAML with Ruby
- ran git diff --check for the issue-template changes